### PR TITLE
Add testcase to report

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,8 +10,12 @@ builds:
       - CGO_ENABLED=0
     goos:
       - linux
+      - windows
+      - darwin
     goarch:
       - amd64
+      - arm
+      - arm64
 checksum:
   name_template: '{{ .ProjectName }}_checksums.txt'
   algorithm: sha512

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2022 F. Hoffmann-La Roche AG
+Copyright 2023 F. Hoffmann-La Roche AG
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You may download the binary for your OS/distribution from [https://github.com/in
 
 ```bash
 # Assuming you're in the directory which contains the binary
-./junit-xml-diff <old.xml> <new.xml>
+./junit-xml-diff <old.xml> <new.xml> <output.md>
 ```
 
 ### Container

--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # junit-xml-diff
+
+[![GitHub Releases](https://img.shields.io/github/v/release/insightsengineering/junit-xml-diff)](https://github.com/insightsengineering/junit-xml-diff/releases)
+[![go.mod](https://img.shields.io/github/go-mod/go-version/insightsengineering/junit-xml-diff)](go.mod)
+[![Go Report Card](https://goreportcard.com/badge/github.com/insightsengineering/junit-xml-diff)](https://goreportcard.com/report/github.com/insightsengineering/junit-xml-diff)
+[![Lint Code Base](https://github.com/insightsengineering/junit-xml-diff/actions/workflows/lint.yml/badge.svg)](https://github.com/insightsengineering/junit-xml-diff/actions/workflows/lint.yml)
+[![Tests](https://github.com/insightsengineering/junit-xml-diff/actions/workflows/test.yml/badge.svg)](https://github.com/insightsengineering/junit-xml-diff/actions/workflows/test.yml)
+
 Tool for comparing JUnit XML reports
+
+## Usage
+
+### Binary
+
+You may download the binary for your OS/distribution from [https://github.com/insightsengineering/junit-xml-diff/releases](https://github.com/insightsengineering/junit-xml-diff/releases) and run the following command:
+
+```bash
+# Assuming you're in the directory which contains the binary
+./junit-xml-diff <old.xml> <new.xml>
+```
+
+### Container
+
+You can pull a container image for this tool from [https://github.com/insightsengineering/junit-xml-diff/pkgs/container/junit-xml-diff](https://github.com/insightsengineering/junit-xml-diff/pkgs/container/junit-xml-diff).
+
+## License
+
+The project is licensed under the [Apache License, Version 2.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ You may download the binary for your OS/distribution from [https://github.com/in
 ```bash
 # Assuming you're in the directory which contains the binary
 ./junit-xml-diff <old.xml> <new.xml> <output.md> <branch-name-corresponding-to-old-xml> <positive-threshold> <negative-threshold>
+# For help, run:
+./junit-xml-diff
 ```
 
 ### Container

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You may download the binary for your OS/distribution from [https://github.com/in
 
 ```bash
 # Assuming you're in the directory which contains the binary
-./junit-xml-diff <old.xml> <new.xml> <output.md>
+./junit-xml-diff <old.xml> <new.xml> <output.md> <branch-name-corresponding-to-old-xml> <positive-threshold> <negative-threshold>
 ```
 
 ### Container

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/insightsengineering/junit-xml-diff
 
 go 1.19
+
+require github.com/stretchr/testify v1.8.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,17 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -242,7 +242,7 @@ func compareTestSuites(testSuiteOld TestSuitesXML, testSuiteNew TestSuitesXML) m
 	return testSuiteDiff
 }
 
-func compareXMLReports(fileOld, fileNew string) {
+func compareXMLReports(fileOld, fileNew, fileOut string) {
 	xmlFileOld, err := os.Open(fileOld)
 	checkError(err)
 	xmlFileNew, err := os.Open(fileNew)
@@ -270,7 +270,10 @@ func compareXMLReports(fileOld, fileNew string) {
 
 	tmpl, err := template.New("md").Parse(mdtemplate)
 	checkError(err)
-	err = tmpl.Execute(os.Stdout, testReport)
+	outputFile, err := os.Create(fileOut)
+	checkError(err)
+	defer outputFile.Close()
+	err = tmpl.Execute(outputFile, testReport)
 	checkError(err)
 }
 
@@ -294,8 +297,8 @@ const mdtemplate = `
 
 func main() {
 	if len(os.Args) < 3 {
-		fmt.Printf("Usage: %s <old-xml-file-name> <new-xml-file-name>\n", os.Args[0])
+		fmt.Printf("Usage: %s <old-xml-file-name> <new-xml-file-name> <output-file-name>\n", os.Args[0])
 		os.Exit(1)
 	}
-	compareXMLReports(os.Args[1], os.Args[2])
+	compareXMLReports(os.Args[1], os.Args[2], os.Args[3])
 }

--- a/main.go
+++ b/main.go
@@ -171,7 +171,7 @@ func compareTestCases(testSuiteOld TestSuitesXML, testSuiteNew TestSuitesXML) ma
 			// Test case exists only in new XML.
 			testCaseTimeDiff[k] = TestCaseDiff{
 				"👶",
-				formatFloat(testCaseTimesNew[k].Time, true, true),
+				formatFloat(testCaseTimesNew[k].Time, true, false),
 				testCaseTimesNew[k].TestCaseName,
 				testCaseTimesNew[k].ClassName,
 				testCaseTimesNew[k].SuiteName,
@@ -186,7 +186,7 @@ func compareTestCases(testSuiteOld TestSuitesXML, testSuiteNew TestSuitesXML) ma
 			// Test case exists only in old XML.
 			testCaseTimeDiff[k] = TestCaseDiff{
 				"💀",
-				formatFloat(testCaseTimesOld[k].Time, true, true),
+				formatFloat(testCaseTimesOld[k].Time, true, false),
 				testCaseTimesOld[k].TestCaseName,
 				testCaseTimesOld[k].ClassName,
 				testCaseTimesOld[k].SuiteName,
@@ -238,7 +238,7 @@ func compareTestSuites(testSuiteOld TestSuitesXML, testSuiteNew TestSuitesXML) m
 			// Test suite name exists only in new XML.
 			testSuiteDiff[testSuiteName] = TestSuiteDiff{
 				"👶",
-				formatFloat(float32(newTimeFloat), true, true),
+				formatFloat(float32(newTimeFloat), true, false),
 				formatInt(newTests),
 				formatInt(newSkipped),
 				formatInt(newFailures),
@@ -257,7 +257,7 @@ func compareTestSuites(testSuiteOld TestSuitesXML, testSuiteNew TestSuitesXML) m
 			// Test suite name exists only in old XML.
 			testSuiteDiff[testSuiteName] = TestSuiteDiff{
 				"💀",
-				formatFloat(-1*float32(oldTimeFloat), true, true),
+				formatFloat(-1*float32(oldTimeFloat), true, false),
 				formatInt(-1 * testSuiteTestsOld[testSuiteName]),
 				formatInt(-1 * testSuiteSkippedOld[testSuiteName]),
 				formatInt(-1 * testSuiteFailuresOld[testSuiteName]),
@@ -343,7 +343,7 @@ const testCaseTemplate = `
 `
 
 func main() {
-	if len(os.Args) < 3 {
+	if len(os.Args) < 7 {
 		// <branch-name-for-old-xml> is typically main
 		// if time difference is between 0 and <positive-threshold> it's treated as 0
 		// if time difference is between <negative-threshold> and 0 it's treated as 0

--- a/main.go
+++ b/main.go
@@ -281,7 +281,7 @@ const mdtemplate = `
 | Test Suite | $Status$ | $±Time$ | $±Tests$ | $±Skipped$ | $±Failures$ | $±Errors$ |
 |:----:|:----:|:----:|:-----:|:-------:|:--------:|:------:|
 {{- range $key, $value := .SuiteDiff }}
-| ${{ $key }}$ | ${{ .SuiteStatus }}$ | ${{ .TimeDiff }}$ | ${{ .TestsDiff }}$ | ${{ .SkippedDiff }}$ | ${{ .FailuresDiff }}$ | ${{ .ErrorsDiff }}$ |
+| ${{ $key }}$ | $ {{ .SuiteStatus }}$ | ${{ .TimeDiff }}$ | ${{ .TestsDiff }}$ | ${{ .SkippedDiff }}$ | ${{ .FailuresDiff }}$ | ${{ .ErrorsDiff }}$ |
 {{- end}}
 
 <details>
@@ -290,7 +290,7 @@ const mdtemplate = `
 | Test Case | $Status$ | $±Time$ | Test Suite |
 |:----:|:----:|:----:|:----:|
 {{- range $key, $value := .CaseDiff }}
-| {{ .TestCaseName }} | ${{ .TestCaseStatus }}$ | ${{ .TimeDiff }}$ | {{ .SuiteName }} |
+| {{ .TestCaseName }} | $ {{ .TestCaseStatus }}$ | ${{ .TimeDiff }}$ | {{ .SuiteName }} |
 {{- end}}
 </details>
 `

--- a/main.go
+++ b/main.go
@@ -186,7 +186,7 @@ func compareTestCases(testSuiteOld TestSuitesXML, testSuiteNew TestSuitesXML) ma
 			// Test case exists only in old XML.
 			testCaseTimeDiff[k] = TestCaseDiff{
 				"💀",
-				formatFloat(-1 * testCaseTimesOld[k].Time, true, false),
+				formatFloat(-1*testCaseTimesOld[k].Time, true, false),
 				testCaseTimesOld[k].TestCaseName,
 				testCaseTimesOld[k].ClassName,
 				testCaseTimesOld[k].SuiteName,

--- a/main.go
+++ b/main.go
@@ -128,7 +128,7 @@ func formatFloat(number float32, addPlusSign bool, roundToThreshold bool) string
 	if number > 0 && addPlusSign {
 		plusSign = "+"
 	}
-	return fmt.Sprintf("$%s%.3f$", plusSign, number)
+	return fmt.Sprintf("$%s%.2f$", plusSign, number)
 }
 
 func getDiffEmoji(formattedTime string) string {
@@ -186,7 +186,7 @@ func compareTestCases(testSuiteOld TestSuitesXML, testSuiteNew TestSuitesXML) ma
 			// Test case exists only in old XML.
 			testCaseTimeDiff[k] = TestCaseDiff{
 				"💀",
-				formatFloat(testCaseTimesOld[k].Time, true, false),
+				formatFloat(-1 * testCaseTimesOld[k].Time, true, false),
 				testCaseTimesOld[k].TestCaseName,
 				testCaseTimesOld[k].ClassName,
 				testCaseTimesOld[k].SuiteName,

--- a/main.go
+++ b/main.go
@@ -21,19 +21,21 @@ type TestSuitesXML struct {
 }
 
 type TestSuite struct {
-	XMLName  xml.Name `xml:"testsuite"`
-	Time     string   `xml:"time,attr"`
-	Name     string   `xml:"name,attr"`
-	Tests    int      `xml:"tests,attr"`
-	Skipped  int      `xml:"skipped,attr"`
-	Failures int      `xml:"failures,attr"`
-	Errors   int      `xml:"errors,attr"`
+	XMLName   xml.Name   `xml:"testsuite"`
+	Time      string     `xml:"time,attr"`
+	Name      string     `xml:"name,attr"`
+	Tests     int        `xml:"tests,attr"`
+	Skipped   int        `xml:"skipped,attr"`
+	Failures  int        `xml:"failures,attr"`
+	Errors    int        `xml:"errors,attr"`
+	TestCases []TestCase `xml:"testcase"`
 }
 
 type TestCase struct {
-	XMLName xml.Name `xml:"testcase"`
-	Time    string   `xml:"time,attr"`
-	Name    string   `xml:"name,attr"`
+	XMLName   xml.Name `xml:"testcase"`
+	Time      string   `xml:"time,attr"`
+	Name      string   `xml:"name,attr"`
+	ClassName string   `xml:"classname,attr"`
 }
 
 type TestSuiteDiff struct {
@@ -45,7 +47,27 @@ type TestSuiteDiff struct {
 	ErrorsDiff   string
 }
 
-func getTestSuitesTime(testSuiteXML TestSuitesXML) (map[string]string, map[string]int,
+type TestCaseTime struct {
+	Time         float32
+	SuiteName    string
+	ClassName    string
+	TestCaseName string
+}
+
+type TestCaseDiff struct {
+	TestCaseStatus string
+	TimeDiff       string
+	TestCaseName   string
+	ClassName      string
+	SuiteName      string
+}
+
+type TestReport struct {
+	SuiteDiff map[string]TestSuiteDiff
+	CaseDiff  map[string]TestCaseDiff
+}
+
+func getTestSuites(testSuiteXML TestSuitesXML) (map[string]string, map[string]int,
 	map[string]int, map[string]int, map[string]int) {
 	testSuiteTimes := make(map[string]string)
 	testSuiteTests := make(map[string]int)
@@ -62,14 +84,33 @@ func getTestSuitesTime(testSuiteXML TestSuitesXML) (map[string]string, map[strin
 	return testSuiteTimes, testSuiteTests, testSuiteSkipped, testSuiteFailures, testSuiteErrors
 }
 
-func getTestCaseTime(testSuiteXML TestSuitesXML) (map[string]string, map[string]string) {
-	testSuiteTimes := make(map[string]string)
-	testSuiteTestCases := make(map[string]string)
+func getTestCases(testSuiteXML TestSuitesXML) map[string]TestCaseTime {
+	// Test case is identified by: testsuitename:testcaseclassname:testcasename
+	testCaseTimes := make(map[string]TestCaseTime)
 	for _, v := range testSuiteXML.TestSuites {
-		testSuiteTimes[v.Name] = v.Time
-		testSuiteTestCases[v.Name] = v.Tests
+		testSuiteName := v.Name
+		for _, testCase := range v.TestCases {
+			testCaseTime, err := strconv.ParseFloat(testCase.Time, 32)
+			checkError(err)
+			testCaseID := testSuiteName + ":" + testCase.ClassName + ":" + testCase.Name
+			// It may happen that there are multiple test cases with the same class name and name inside a test suite.
+			// In that case, times of such cases are added to each other.
+			testCaseTimeEntry, ok := testCaseTimes[testCaseID]
+			if ok {
+				testCaseTimeEntry.Time += float32(testCaseTime)
+				testCaseTimes[testCaseID] = testCaseTimeEntry
+			} else {
+				testCaseTimes[testCaseID] = TestCaseTime{
+					float32(testCaseTime),
+					testSuiteName,
+					testCase.ClassName,
+					testCase.Name,
+				}
+
+			}
+		}
 	}
-	return testSuiteTimes, testSuiteTestCases
+	return testCaseTimes
 }
 
 func formatFloat(number float32) string {
@@ -88,21 +129,61 @@ func formatInt(number int) string {
 	return plusSign + strconv.Itoa(number)
 }
 
-func compareTestSuites(testSuiteOld []byte, testSuiteNew []byte) map[string]TestSuiteDiff {
-	var testSuiteNewXML TestSuitesXML
-	var testSuiteOldXML TestSuitesXML
-	err := xml.Unmarshal(testSuiteNew, &testSuiteNewXML)
-	checkError(err)
-	err = xml.Unmarshal(testSuiteOld, &testSuiteOldXML)
-	checkError(err)
+func compareTestCases(testSuiteOld TestSuitesXML, testSuiteNew TestSuitesXML) map[string]TestCaseDiff {
+	testCaseTimesOld := getTestCases(testSuiteOld)
+	testCaseTimesNew := getTestCases(testSuiteNew)
+	testCaseTimeDiff := make(map[string]TestCaseDiff)
+	// Iterate through new test cases times.
+	for k := range testCaseTimesNew {
+		// Check if the test case existed previously.
+		_, ok := testCaseTimesOld[k]
+		if ok {
+			// Test case exists both in old and new XML.
+			testCaseTimeDiff[k] = TestCaseDiff{
+				"",
+				formatFloat(testCaseTimesNew[k].Time - testCaseTimesOld[k].Time),
+				testCaseTimesNew[k].TestCaseName,
+				testCaseTimesNew[k].ClassName,
+				testCaseTimesNew[k].SuiteName,
+			}
+		} else {
+			// Test case exists only in new XML.
+			testCaseTimeDiff[k] = TestCaseDiff{
+				"➕",
+				formatFloat(testCaseTimesNew[k].Time),
+				testCaseTimesNew[k].TestCaseName,
+				testCaseTimesNew[k].ClassName,
+				testCaseTimesNew[k].SuiteName,
+			}
+		}
+	}
+	// Iterate through old test cases times.
+	for k := range testCaseTimesOld {
+		_, ok := testCaseTimesNew[k]
+		if !ok {
+			// Test case exists only in old XML.
+			testCaseTimeDiff[k] = TestCaseDiff{
+				"➖",
+				formatFloat(testCaseTimesOld[k].Time),
+				testCaseTimesOld[k].TestCaseName,
+				testCaseTimesOld[k].ClassName,
+				testCaseTimesOld[k].SuiteName,
+			}
+		}
+	}
+	return testCaseTimeDiff
+}
+
+func compareTestSuites(testSuiteOld TestSuitesXML, testSuiteNew TestSuitesXML) map[string]TestSuiteDiff {
+
 	testSuiteTimesOld, testSuiteTestsOld, testSuiteSkippedOld,
-		testSuiteFailuresOld, testSuiteErrorsOld := getTestSuitesTime(testSuiteOldXML)
+		testSuiteFailuresOld, testSuiteErrorsOld := getTestSuites(testSuiteOld)
 	testSuiteTimesNew, testSuiteTestsNew, testSuiteSkippedNew,
-		testSuiteFailuresNew, testSuiteErrorsNew := getTestSuitesTime(testSuiteNewXML)
+		testSuiteFailuresNew, testSuiteErrorsNew := getTestSuites(testSuiteNew)
 	testSuiteDiff := make(map[string]TestSuiteDiff)
 
 	// Iterate through test suites in new XML.
-	for _, v := range testSuiteNewXML.TestSuites {
+	for _, v := range testSuiteNew.TestSuites {
 		testSuiteName := v.Name
 		newTime := testSuiteTimesNew[testSuiteName]
 		newTimeFloat, err := strconv.ParseFloat(newTime, 32)
@@ -112,7 +193,7 @@ func compareTestSuites(testSuiteOld []byte, testSuiteNew []byte) map[string]Test
 		newFailures := testSuiteFailuresNew[testSuiteName]
 		newErrors := testSuiteErrorsNew[testSuiteName]
 		// Check if the test suite existed previously.
-		// Keys in all maps returned by getTestSuitesTimes are the same,
+		// Keys in all maps returned by getTestSuites are the same,
 		// so it is okay to iterate through any of these maps.
 		_, ok := testSuiteTimesOld[testSuiteName]
 		if ok {
@@ -141,7 +222,7 @@ func compareTestSuites(testSuiteOld []byte, testSuiteNew []byte) map[string]Test
 		}
 	}
 	// Iterate through test suites in old XML.
-	for _, v := range testSuiteOldXML.TestSuites {
+	for _, v := range testSuiteOld.TestSuites {
 		testSuiteName := v.Name
 		_, ok := testSuiteTimesNew[v.Name]
 		if !ok {
@@ -162,16 +243,28 @@ func compareTestSuites(testSuiteOld []byte, testSuiteNew []byte) map[string]Test
 }
 
 const mdtemplate = `
-|Test Name|Status|±Time|±Tests|±Skipped|±Failures|±Errors|
-|----|------|----|-----|-------|--------|------|
-{{- range $key, $value := .}}
-|{{ $key }}|{{ $value.SuiteStatus }}|{{ $value.TimeDiff }}|{{ $value.TestsDiff }}|{{ $value.SkippedDiff }}|{{ $value.FailuresDiff }}|{{ $value.ErrorsDiff }}|
+|Test Suite|Status|±Time|±Tests|±Skipped|±Failures|±Errors|
+|----|----|----|-----|-------|--------|------|
+{{- range $key, $value := .SuiteDiff }}
+|{{ $key }}|{{ .SuiteStatus }}|{{ .TimeDiff }}|{{ .TestsDiff }}|{{ .SkippedDiff }}|{{ .FailuresDiff }}|{{ .ErrorsDiff }}|
 {{- end}}
+
+<details>
+  <summary>Click me</summary>
+
+|Test Suite|Class|Test Name|Status|±Time|
+|----|----|----|----|----|
+{{- range $key, $value := .CaseDiff }}
+|{{ .SuiteName }}|{{ .ClassName }}|{{ .TestCaseName }}|{{ .TestCaseStatus }}|{{ .TimeDiff }}|
+{{- end}}
+</details>
 `
+
+// TODO is class name relevant? It is mostly the same as test suite name
 
 func main() {
 	if len(os.Args) < 3 {
-		fmt.Printf("Usage: ./%s <old-xml-file-name> <new-xml-file-name>\n", os.Args[0])
+		fmt.Printf("Usage: %s <old-xml-file-name> <new-xml-file-name>\n", os.Args[0])
 		os.Exit(1)
 	}
 	xmlFileOld, err := os.Open(os.Args[1])
@@ -185,10 +278,22 @@ func main() {
 	byteValueNew, err := io.ReadAll(xmlFileNew)
 	checkError(err)
 
-	testSuiteDiff := compareTestSuites(byteValueOld, byteValueNew)
+	var testSuiteNewXML TestSuitesXML
+	var testSuiteOldXML TestSuitesXML
+	err = xml.Unmarshal(byteValueNew, &testSuiteNewXML)
+	checkError(err)
+	err = xml.Unmarshal(byteValueOld, &testSuiteOldXML)
+	checkError(err)
+
+	testSuiteDiff := compareTestSuites(testSuiteOldXML, testSuiteNewXML)
+	testCasesDiff := compareTestCases(testSuiteOldXML, testSuiteNewXML)
+
+	var testReport TestReport
+	testReport.SuiteDiff = testSuiteDiff
+	testReport.CaseDiff = testCasesDiff
 
 	tmpl, err := template.New("md").Parse(mdtemplate)
 	checkError(err)
-	err = tmpl.Execute(os.Stdout, testSuiteDiff)
+	err = tmpl.Execute(os.Stdout, testReport)
 	checkError(err)
 }

--- a/main.go
+++ b/main.go
@@ -344,10 +344,10 @@ const testCaseTemplate = `
 
 func main() {
 	if len(os.Args) < 7 {
-		// <branch-name-for-old-xml> is typically main
-		// if time difference is between 0 and <positive-threshold> it's treated as 0
-		// if time difference is between <negative-threshold> and 0 it's treated as 0
 		fmt.Printf("Usage: %s <old-xml-file-name> <new-xml-file-name> <output-file-name> <branch-name-for-old-xml> <positive-threshold> <negative-threshold>\n", os.Args[0])
+		fmt.Println("<branch-name-for-old-xml> is typically main, or other branch from which the new-xml report is compared with.")
+		fmt.Println("If time difference is between 0 and <positive-threshold> seconds it's treated as 0 seconds.")
+		fmt.Println("If time difference is between <negative-threshold> and 0 seconds it's treated as 0 seconds.")
 		os.Exit(1)
 	}
 

--- a/main.go
+++ b/main.go
@@ -305,9 +305,10 @@ func compareXMLReports(fileOld, fileNew, fileOut, branch string) {
 	var markdownTemplate string
 	if len(testSuiteDiff) > 20 {
 		// If there are more than 20 test suites, markdown table with test suites should be collapsible.
-		markdownTemplate = longTestSuiteTemplatePrefix + testSuiteTemplate + longTestSuiteTemplateSuffix + testCaseTemplate
+		markdownTemplate = templateHeader + longTestSuiteTemplatePrefix + testSuiteTemplate +
+			longTestSuiteTemplateSuffix + testCaseTemplate
 	} else {
-		markdownTemplate = testSuiteTemplate + testCaseTemplate
+		markdownTemplate = templateHeader + testSuiteTemplate + testCaseTemplate
 	}
 
 	tmpl, err := template.New("md").Parse(markdownTemplate)
@@ -319,6 +320,10 @@ func compareXMLReports(fileOld, fileNew, fileOut, branch string) {
 	checkError(err)
 }
 
+const templateHeader = `
+## Unit Test Performance Difference
+`
+
 const longTestSuiteTemplatePrefix = `
 <details>
   <summary><b>Test suite performance difference</b></summary>
@@ -329,7 +334,7 @@ const longTestSuiteTemplateSuffix = `
 `
 
 const testSuiteTemplate = `
-| Test Suite | $Status$ | Time for ` + "`" + `{{ .DiffBranch }}` + "`" + ` | $±Time$ | $±Tests$ | $±Skipped$ | $±Failures$ | $±Errors$ |
+| Test Suite | $Status$ | Time on ` + "`" + `{{ .DiffBranch }}` + "`" + ` | $±Time$ | $±Tests$ | $±Skipped$ | $±Failures$ | $±Errors$ |
 |:-----|:----:|:----:|:-----:|:-------:|:--------:|:------:|:------:|
 {{- range $key, $value := .SuiteDiff }}
 | {{ $key }} | {{ .SuiteStatus }} | {{ .TimeDiffBranch }} | {{ .TimeDiff }} | ${{ .TestsDiff }}$ | ${{ .SkippedDiff }}$ | ${{ .FailuresDiff }}$ | ${{ .ErrorsDiff }}$ |
@@ -340,7 +345,7 @@ const testCaseTemplate = `
 <details>
   <summary><b>Additional test case details</b></summary>
 
-| Test Suite | $Status$ | Time for ` + "`" + `{{ .DiffBranch }}` + "`" + ` | $±Time$ | Test Case |
+| Test Suite | $Status$ | Time on ` + "`" + `{{ .DiffBranch }}` + "`" + ` | $±Time$ | Test Case |
 |:-----|:----:|:----:|:----:|:-----|
 {{- range $key, $value := .CaseDiff }}
 | {{ .SuiteName }} | {{ .TestCaseStatus }} | {{ .TimeDiffBranch }} | {{ .TimeDiff }} | {{ .TestCaseName }} |

--- a/main.go
+++ b/main.go
@@ -287,7 +287,7 @@ const mdtemplate = `
 |Test Case|Status|±Time|Test Suite|
 |----|----|----|----|
 {{- range $key, $value := .CaseDiff }}
-|{{ .SuiteName }}|{{ .TestCaseName }}|{{ .TestCaseStatus }}|{{ .TimeDiff }}|
+|{{ .TestCaseName }}|{{ .TestCaseStatus }}|{{ .TimeDiff }}|{{ .SuiteName }}|
 {{- end}}
 </details>
 `

--- a/main.go
+++ b/main.go
@@ -30,6 +30,12 @@ type TestSuite struct {
 	Errors   int      `xml:"errors,attr"`
 }
 
+type TestCase struct {
+	XMLName xml.Name `xml:"testcase"`
+	Time    string   `xml:"time,attr"`
+	Name    string   `xml:"name,attr"`
+}
+
 type TestSuiteDiff struct {
 	SuiteStatus  string
 	TimeDiff     string
@@ -54,6 +60,16 @@ func getTestSuitesTime(testSuiteXML TestSuitesXML) (map[string]string, map[strin
 		testSuiteErrors[v.Name] = v.Errors
 	}
 	return testSuiteTimes, testSuiteTests, testSuiteSkipped, testSuiteFailures, testSuiteErrors
+}
+
+func getTestCaseTime(testSuiteXML TestSuitesXML) (map[string]string, map[string]string) {
+	testSuiteTimes := make(map[string]string)
+	testSuiteTestCases := make(map[string]string)
+	for _, v := range testSuiteXML.TestSuites {
+		testSuiteTimes[v.Name] = v.Time
+		testSuiteTestCases[v.Name] = v.Tests
+	}
+	return testSuiteTimes, testSuiteTestCases
 }
 
 func formatFloat(number float32) string {
@@ -146,7 +162,7 @@ func compareTestSuites(testSuiteOld []byte, testSuiteNew []byte) map[string]Test
 }
 
 const mdtemplate = `
-|Name|Status|Time|Tests|Skipped|Failures|Errors|
+|Test Name|Status|±Time|±Tests|±Skipped|±Failures|±Errors|
 |----|------|----|-----|-------|--------|------|
 {{- range $key, $value := .}}
 |{{ $key }}|{{ $value.SuiteStatus }}|{{ $value.TimeDiff }}|{{ $value.TestsDiff }}|{{ $value.SkippedDiff }}|{{ $value.FailuresDiff }}|{{ $value.ErrorsDiff }}|

--- a/main.go
+++ b/main.go
@@ -278,19 +278,19 @@ func compareXMLReports(fileOld, fileNew, fileOut string) {
 }
 
 const mdtemplate = `
-|Test Suite|Status|±Time|±Tests|±Skipped|±Failures|±Errors|
-|----|----|----|-----|-------|--------|------|
+| Test Suite | $Status$ | $±Time$ | $±Tests$ | $±Skipped$ | $±Failures$ | $±Errors$ |
+|:----:|:----:|:----:|:-----:|:-------:|:--------:|:------:|
 {{- range $key, $value := .SuiteDiff }}
-|{{ $key }}|{{ .SuiteStatus }}|{{ .TimeDiff }}|{{ .TestsDiff }}|{{ .SkippedDiff }}|{{ .FailuresDiff }}|{{ .ErrorsDiff }}|
+| ${{ $key }}$ | ${{ .SuiteStatus }}$ | ${{ .TimeDiff }}$ | ${{ .TestsDiff }}$ | ${{ .SkippedDiff }}$ | ${{ .FailuresDiff }}$ | ${{ .ErrorsDiff }}$ |
 {{- end}}
 
 <details>
   <summary><b>Additional test case details</b></summary>
 
-|Test Case|Status|±Time|Test Suite|
-|----|----|----|----|
+| Test Case | $Status$ | $±Time$ | Test Suite |
+|:----:|:----:|:----:|:----:|
 {{- range $key, $value := .CaseDiff }}
-|{{ .TestCaseName }}|{{ .TestCaseStatus }}|{{ .TimeDiff }}|{{ .SuiteName }}|
+| {{ .TestCaseName }} | ${{ .TestCaseStatus }}$ | ${{ .TimeDiff }}$ | {{ .SuiteName }} |
 {{- end}}
 </details>
 `

--- a/main.go
+++ b/main.go
@@ -159,13 +159,16 @@ func compareTestCases(testSuiteOld TestSuitesXML, testSuiteNew TestSuitesXML) ma
 		if ok {
 			// Test case exists both in old and new XML.
 			formattedTimeDiff := formatFloat(testCaseTimesNew[k].Time-testCaseTimesOld[k].Time, true, true)
-			testCaseTimeDiff[k] = TestCaseDiff{
-				getDiffEmoji(formattedTimeDiff),
-				formattedTimeDiff,
-				testCaseTimesNew[k].TestCaseName,
-				testCaseTimesNew[k].ClassName,
-				testCaseTimesNew[k].SuiteName,
-				formatFloat(testCaseTimesOld[k].Time, false, false),
+			if formattedTimeDiff != "" {
+				// Add a row to markdown table only if time difference is significant.
+				testCaseTimeDiff[k] = TestCaseDiff{
+					getDiffEmoji(formattedTimeDiff),
+					formattedTimeDiff,
+					testCaseTimesNew[k].TestCaseName,
+					testCaseTimesNew[k].ClassName,
+					testCaseTimesNew[k].SuiteName,
+					formatFloat(testCaseTimesOld[k].Time, false, false),
+				}
 			}
 		} else {
 			// Test case exists only in new XML.
@@ -225,14 +228,17 @@ func compareTestSuites(testSuiteOld TestSuitesXML, testSuiteNew TestSuitesXML) m
 			oldTimeFloat, err := strconv.ParseFloat(oldTime, 32)
 			checkError(err)
 			formattedTimeDiff := formatFloat(float32(newTimeFloat-oldTimeFloat), true, true)
-			testSuiteDiff[testSuiteName] = TestSuiteDiff{
-				getDiffEmoji(formattedTimeDiff),
-				formattedTimeDiff,
-				formatInt(newTests - testSuiteTestsOld[testSuiteName]),
-				formatInt(newSkipped - testSuiteSkippedOld[testSuiteName]),
-				formatInt(newFailures - testSuiteFailuresOld[testSuiteName]),
-				formatInt(newErrors - testSuiteErrorsOld[testSuiteName]),
-				formatFloat(float32(oldTimeFloat), false, false),
+			if formattedTimeDiff != "" {
+				// Add a row to markdown table only if time difference is significant.
+				testSuiteDiff[testSuiteName] = TestSuiteDiff{
+					getDiffEmoji(formattedTimeDiff),
+					formattedTimeDiff,
+					formatInt(newTests - testSuiteTestsOld[testSuiteName]),
+					formatInt(newSkipped - testSuiteSkippedOld[testSuiteName]),
+					formatInt(newFailures - testSuiteFailuresOld[testSuiteName]),
+					formatInt(newErrors - testSuiteErrorsOld[testSuiteName]),
+					formatFloat(float32(oldTimeFloat), false, false),
+				}
 			}
 		} else {
 			// Test suite name exists only in new XML.

--- a/main.go
+++ b/main.go
@@ -243,19 +243,19 @@ func compareTestSuites(testSuiteOld TestSuitesXML, testSuiteNew TestSuitesXML) m
 }
 
 const mdtemplate = `
-|Test Suite|Status|±Time|±Tests|±Skipped|±Failures|±Errors|
+|Test suite|Status|±Time|±Tests|±Skipped|±Failures|±Errors|
 |----|----|----|-----|-------|--------|------|
 {{- range $key, $value := .SuiteDiff }}
 |{{ $key }}|{{ .SuiteStatus }}|{{ .TimeDiff }}|{{ .TestsDiff }}|{{ .SkippedDiff }}|{{ .FailuresDiff }}|{{ .ErrorsDiff }}|
 {{- end}}
 
 <details>
-  <summary>Click me</summary>
+  <summary>Additional test case details</summary>
 
-|Test Suite|Class|Test Name|Status|±Time|
-|----|----|----|----|----|
+|Test suite|Test case|Status|±Time|
+|----|----|----|----|
 {{- range $key, $value := .CaseDiff }}
-|{{ .SuiteName }}|{{ .ClassName }}|{{ .TestCaseName }}|{{ .TestCaseStatus }}|{{ .TimeDiff }}|
+|{{ .SuiteName }}|{{ .TestCaseName }}|{{ .TestCaseStatus }}|{{ .TimeDiff }}|
 {{- end}}
 </details>
 `

--- a/main_test.go
+++ b/main_test.go
@@ -41,5 +41,6 @@ func Test_compareXMLReports(t *testing.T) {
 	checkError(err)
 	compareXMLReports("testdata/old.xml", "testdata/new.xml", "testdata/out.md")
 	outputBytes, err := os.ReadFile("testdata/out.md")
+	checkError(err)
 	assert.Equal(t, string(outputBytes), expectedResult)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -8,38 +8,40 @@ import (
 )
 
 const expectedResult = `
-| Test Suite | $Status$ | $±Time$ | $±Tests$ | $±Skipped$ | $±Failures$ | $±Errors$ |
-|:----:|:----:|:----:|:-----:|:-------:|:--------:|:------:|
-| testsuite1 |  | $+0.300$ | $+2$ | $+2$ | $0$ | $-2$ |
-| testsuite2 |  | $0.000$ | $-1$ | $+2$ | $-2$ | $0$ |
-| testsuite3 | $-$ | $-3.250$ | $-4$ | $0$ | $-3$ | $0$ |
-| testsuite5 | $+$ | $+7.158$ | $+3$ | $0$ | $0$ | $+1$ |
+| Test Suite | $Status$ | Time for ` + "`" + `main` + "`" + ` | $±Time$ | $±Tests$ | $±Skipped$ | $±Failures$ | $±Errors$ |
+|:-----|:----:|:----:|:-----:|:-------:|:--------:|:------:|:------:|
+| testsuite1 | 💔 | $1.250$ | $+1.300$ | $+2$ | $+2$ | $0$ | $-2$ |
+| testsuite2 |  | $2.250$ |  | $-1$ | $+2$ | $-2$ | $0$ |
+| testsuite3 | 💀 | $3.250$ | $-3.250$ | $-4$ | $0$ | $-3$ | $0$ |
+| testsuite5 | 👶 |  | $+7.158$ | $+3$ | $0$ | $0$ | $+1$ |
 
 <details>
   <summary><b>Additional test case details</b></summary>
 
-| Test Suite | $Status$ | $±Time$ | Test Case |
-|:----:|:----:|:----:|:-----|
-| testsuite1 |  | $+5.960$ | testcase1 |
-| testsuite1 |  | $0.000$ | testcase2 |
-| testsuite1 |  | $0.000$ | testcase3 |
-| testsuite1 | $+$ | $+0.550$ | testcase3a |
-| testsuite1 | $+$ | $+0.550$ | testcase3b |
-| testsuite2 |  | $-0.100$ | testcase4 |
-| testsuite2 |  | $+2.000$ | testcase5 |
-| testsuite2 | $-$ | $+0.080$ | testcase6 |
-| testsuite3 | $-$ | $+0.250$ | testcase40 |
-| testsuite3 | $-$ | $+0.800$ | testcase50 |
-| testsuite3 | $-$ | $+0.580$ | testcase60 |
-| testsuite5 | $+$ | $+1.150$ | testcase400 |
-| testsuite5 | $+$ | $+5.111$ | testcase500 |
+| Test Suite | $Status$ | Time for ` + "`" + `main` + "`" + ` | $±Time$ | Test Case |
+|:-----|:----:|:----:|:----:|:-----|
+| testsuite1 | 💔 | $1.210$ | $+5.960$ | testcase1 |
+| testsuite1 |  | $0.320$ |  | testcase2 |
+| testsuite1 |  | $0.550$ |  | testcase3 |
+| testsuite1 | 👶 |  | $+0.550$ | testcase3a |
+| testsuite1 | 👶 |  | $+0.550$ | testcase3b |
+| testsuite2 | 💚 | $5.150$ | $-5.100$ | testcase4 |
+| testsuite2 | 💔 | $0.100$ | $+2.000$ | testcase5 |
+| testsuite2 | 💀 | $0.080$ |  | testcase6 |
+| testsuite3 | 💀 | $0.250$ | $+0.250$ | testcase40 |
+| testsuite3 | 💀 | $0.800$ | $+0.800$ | testcase50 |
+| testsuite3 | 💀 | $0.580$ | $+0.580$ | testcase60 |
+| testsuite5 | 👶 |  | $+1.150$ | testcase400 |
+| testsuite5 | 👶 |  | $+5.111$ | testcase500 |
 </details>
 `
 
 func Test_compareXMLReports(t *testing.T) {
+	positiveThreshold = 0.2
+	negativeThreshold = 0.2
 	err := os.MkdirAll("testdata", os.ModePerm)
 	checkError(err)
-	compareXMLReports("testdata/old.xml", "testdata/new.xml", "testdata/out.md")
+	compareXMLReports("testdata/old.xml", "testdata/new.xml", "testdata/out.md", "main")
 	outputBytes, err := os.ReadFile("testdata/out.md")
 	checkError(err)
 	assert.Equal(t, string(outputBytes), expectedResult)

--- a/main_test.go
+++ b/main_test.go
@@ -8,7 +8,9 @@ import (
 )
 
 const expectedResult = `
-| Test Suite | $Status$ | Time for ` + "`" + `main` + "`" + ` | $±Time$ | $±Tests$ | $±Skipped$ | $±Failures$ | $±Errors$ |
+## Unit Test Performance Difference
+
+| Test Suite | $Status$ | Time on ` + "`" + `main` + "`" + ` | $±Time$ | $±Tests$ | $±Skipped$ | $±Failures$ | $±Errors$ |
 |:-----|:----:|:----:|:-----:|:-------:|:--------:|:------:|:------:|
 | testsuite1 | 💔 | $1.25$ | $+1.30$ | $+2$ | $+2$ | $0$ | $-2$ |
 | testsuite3 | 💀 | $3.25$ | $-3.25$ | $-4$ | $0$ | $-3$ | $0$ |
@@ -17,7 +19,7 @@ const expectedResult = `
 <details>
   <summary><b>Additional test case details</b></summary>
 
-| Test Suite | $Status$ | Time for ` + "`" + `main` + "`" + ` | $±Time$ | Test Case |
+| Test Suite | $Status$ | Time on ` + "`" + `main` + "`" + ` | $±Time$ | Test Case |
 |:-----|:----:|:----:|:----:|:-----|
 | testsuite1 | 💔 | $1.21$ | $+5.96$ | testcase1 |
 | testsuite1 | 👶 |  | $+0.55$ | testcase3a |

--- a/main_test.go
+++ b/main_test.go
@@ -10,29 +10,29 @@ import (
 const expectedResult = `
 | Test Suite | $Status$ | Time for ` + "`" + `main` + "`" + ` | $±Time$ | $±Tests$ | $±Skipped$ | $±Failures$ | $±Errors$ |
 |:-----|:----:|:----:|:-----:|:-------:|:--------:|:------:|:------:|
-| testsuite1 | 💔 | $1.250$ | $+1.300$ | $+2$ | $+2$ | $0$ | $-2$ |
-| testsuite2 |  | $2.250$ |  | $-1$ | $+2$ | $-2$ | $0$ |
-| testsuite3 | 💀 | $3.250$ | $-3.250$ | $-4$ | $0$ | $-3$ | $0$ |
-| testsuite5 | 👶 |  | $+7.158$ | $+3$ | $0$ | $0$ | $+1$ |
+| testsuite1 | 💔 | $1.25$ | $+1.30$ | $+2$ | $+2$ | $0$ | $-2$ |
+| testsuite2 |  | $2.25$ |  | $-1$ | $+2$ | $-2$ | $0$ |
+| testsuite3 | 💀 | $3.25$ | $-3.25$ | $-4$ | $0$ | $-3$ | $0$ |
+| testsuite5 | 👶 |  | $+7.16$ | $+3$ | $0$ | $0$ | $+1$ |
 
 <details>
   <summary><b>Additional test case details</b></summary>
 
 | Test Suite | $Status$ | Time for ` + "`" + `main` + "`" + ` | $±Time$ | Test Case |
 |:-----|:----:|:----:|:----:|:-----|
-| testsuite1 | 💔 | $1.210$ | $+5.960$ | testcase1 |
-| testsuite1 |  | $0.320$ |  | testcase2 |
-| testsuite1 |  | $0.550$ |  | testcase3 |
-| testsuite1 | 👶 |  | $+0.550$ | testcase3a |
-| testsuite1 | 👶 |  | $+0.550$ | testcase3b |
-| testsuite2 | 💚 | $5.150$ | $-5.100$ | testcase4 |
-| testsuite2 | 💔 | $0.100$ | $+2.000$ | testcase5 |
-| testsuite2 | 💀 | $0.080$ | $+0.080$ | testcase6 |
-| testsuite3 | 💀 | $0.250$ | $+0.250$ | testcase40 |
-| testsuite3 | 💀 | $0.800$ | $+0.800$ | testcase50 |
-| testsuite3 | 💀 | $0.580$ | $+0.580$ | testcase60 |
-| testsuite5 | 👶 |  | $+1.150$ | testcase400 |
-| testsuite5 | 👶 |  | $+5.111$ | testcase500 |
+| testsuite1 | 💔 | $1.21$ | $+5.96$ | testcase1 |
+| testsuite1 |  | $0.32$ |  | testcase2 |
+| testsuite1 |  | $0.55$ |  | testcase3 |
+| testsuite1 | 👶 |  | $+0.55$ | testcase3a |
+| testsuite1 | 👶 |  | $+0.55$ | testcase3b |
+| testsuite2 | 💚 | $5.15$ | $-5.10$ | testcase4 |
+| testsuite2 | 💔 | $0.10$ | $+2.00$ | testcase5 |
+| testsuite2 | 💀 | $0.08$ | $-0.08$ | testcase6 |
+| testsuite3 | 💀 | $0.25$ | $-0.25$ | testcase40 |
+| testsuite3 | 💀 | $0.80$ | $-0.80$ | testcase50 |
+| testsuite3 | 💀 | $0.58$ | $-0.58$ | testcase60 |
+| testsuite5 | 👶 |  | $+1.15$ | testcase400 |
+| testsuite5 | 👶 |  | $+5.11$ | testcase500 |
 </details>
 `
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const expectedResult = `
+|Test Suite|Status|±Time|±Tests|±Skipped|±Failures|±Errors|
+|----|----|----|-----|-------|--------|------|
+|testsuite1||+0.300|+2|+2|0|-2|
+|testsuite2||0.000|-1|+2|-2|0|
+|testsuite3|➖|-3.250|-4|0|-3|0|
+|testsuite5|➕|+7.158|+3|0|0|+1|
+
+<details>
+  <summary><b>Additional test case details</b></summary>
+
+|Test Case|Status|±Time|Test Suite|
+|----|----|----|----|
+|testcase1||+5.960|testsuite1|
+|testcase2||0.000|testsuite1|
+|testcase3||0.000|testsuite1|
+|testcase3a|➕|+0.550|testsuite1|
+|testcase3b|➕|+0.550|testsuite1|
+|testcase4||-0.100|testsuite2|
+|testcase5||+2.000|testsuite2|
+|testcase6|➖|+0.080|testsuite2|
+|testcase40|➖|+0.250|testsuite3|
+|testcase50|➖|+0.800|testsuite3|
+|testcase60|➖|+0.580|testsuite3|
+|testcase400|➕|+1.150|testsuite5|
+|testcase500|➕|+5.111|testsuite5|
+</details>
+`
+
+func Test_compareXMLReports(t *testing.T) {
+	err := os.MkdirAll("testdata", os.ModePerm)
+	checkError(err)
+	compareXMLReports("testdata/old.xml", "testdata/new.xml", "testdata/out.md")
+	outputBytes, err := os.ReadFile("testdata/out.md")
+	assert.Equal(t, string(outputBytes), expectedResult)
+}

--- a/main_test.go
+++ b/main_test.go
@@ -27,7 +27,7 @@ const expectedResult = `
 | testsuite1 | 👶 |  | $+0.550$ | testcase3b |
 | testsuite2 | 💚 | $5.150$ | $-5.100$ | testcase4 |
 | testsuite2 | 💔 | $0.100$ | $+2.000$ | testcase5 |
-| testsuite2 | 💀 | $0.080$ |  | testcase6 |
+| testsuite2 | 💀 | $0.080$ | $+0.080$ | testcase6 |
 | testsuite3 | 💀 | $0.250$ | $+0.250$ | testcase40 |
 | testsuite3 | 💀 | $0.800$ | $+0.800$ | testcase50 |
 | testsuite3 | 💀 | $0.580$ | $+0.580$ | testcase60 |

--- a/main_test.go
+++ b/main_test.go
@@ -8,31 +8,31 @@ import (
 )
 
 const expectedResult = `
-|Test Suite|Status|±Time|±Tests|±Skipped|±Failures|±Errors|
-|----|----|----|-----|-------|--------|------|
-|testsuite1||+0.300|+2|+2|0|-2|
-|testsuite2||0.000|-1|+2|-2|0|
-|testsuite3|➖|-3.250|-4|0|-3|0|
-|testsuite5|➕|+7.158|+3|0|0|+1|
+| Test Suite | $Status$ | $±Time$ | $±Tests$ | $±Skipped$ | $±Failures$ | $±Errors$ |
+|:----:|:----:|:----:|:-----:|:-------:|:--------:|:------:|
+| $testsuite1$ | $ $ | $+0.300$ | $+2$ | $+2$ | $0$ | $-2$ |
+| $testsuite2$ | $ $ | $0.000$ | $-1$ | $+2$ | $-2$ | $0$ |
+| $testsuite3$ | $ ➖$ | $-3.250$ | $-4$ | $0$ | $-3$ | $0$ |
+| $testsuite5$ | $ ➕$ | $+7.158$ | $+3$ | $0$ | $0$ | $+1$ |
 
 <details>
   <summary><b>Additional test case details</b></summary>
 
-|Test Case|Status|±Time|Test Suite|
-|----|----|----|----|
-|testcase1||+5.960|testsuite1|
-|testcase2||0.000|testsuite1|
-|testcase3||0.000|testsuite1|
-|testcase3a|➕|+0.550|testsuite1|
-|testcase3b|➕|+0.550|testsuite1|
-|testcase4||-0.100|testsuite2|
-|testcase5||+2.000|testsuite2|
-|testcase6|➖|+0.080|testsuite2|
-|testcase40|➖|+0.250|testsuite3|
-|testcase50|➖|+0.800|testsuite3|
-|testcase60|➖|+0.580|testsuite3|
-|testcase400|➕|+1.150|testsuite5|
-|testcase500|➕|+5.111|testsuite5|
+| Test Case | $Status$ | $±Time$ | Test Suite |
+|:----:|:----:|:----:|:----:|
+| testcase1 | $ $ | $+5.960$ | testsuite1 |
+| testcase2 | $ $ | $0.000$ | testsuite1 |
+| testcase3 | $ $ | $0.000$ | testsuite1 |
+| testcase3a | $ ➕$ | $+0.550$ | testsuite1 |
+| testcase3b | $ ➕$ | $+0.550$ | testsuite1 |
+| testcase4 | $ $ | $-0.100$ | testsuite2 |
+| testcase5 | $ $ | $+2.000$ | testsuite2 |
+| testcase6 | $ ➖$ | $+0.080$ | testsuite2 |
+| testcase40 | $ ➖$ | $+0.250$ | testsuite3 |
+| testcase50 | $ ➖$ | $+0.800$ | testsuite3 |
+| testcase60 | $ ➖$ | $+0.580$ | testsuite3 |
+| testcase400 | $ ➕$ | $+1.150$ | testsuite5 |
+| testcase500 | $ ➕$ | $+5.111$ | testsuite5 |
 </details>
 `
 

--- a/main_test.go
+++ b/main_test.go
@@ -11,7 +11,6 @@ const expectedResult = `
 | Test Suite | $Status$ | Time for ` + "`" + `main` + "`" + ` | $±Time$ | $±Tests$ | $±Skipped$ | $±Failures$ | $±Errors$ |
 |:-----|:----:|:----:|:-----:|:-------:|:--------:|:------:|:------:|
 | testsuite1 | 💔 | $1.25$ | $+1.30$ | $+2$ | $+2$ | $0$ | $-2$ |
-| testsuite2 |  | $2.25$ |  | $-1$ | $+2$ | $-2$ | $0$ |
 | testsuite3 | 💀 | $3.25$ | $-3.25$ | $-4$ | $0$ | $-3$ | $0$ |
 | testsuite5 | 👶 |  | $+7.16$ | $+3$ | $0$ | $0$ | $+1$ |
 
@@ -21,8 +20,6 @@ const expectedResult = `
 | Test Suite | $Status$ | Time for ` + "`" + `main` + "`" + ` | $±Time$ | Test Case |
 |:-----|:----:|:----:|:----:|:-----|
 | testsuite1 | 💔 | $1.21$ | $+5.96$ | testcase1 |
-| testsuite1 |  | $0.32$ |  | testcase2 |
-| testsuite1 |  | $0.55$ |  | testcase3 |
 | testsuite1 | 👶 |  | $+0.55$ | testcase3a |
 | testsuite1 | 👶 |  | $+0.55$ | testcase3b |
 | testsuite2 | 💚 | $5.15$ | $-5.10$ | testcase4 |

--- a/main_test.go
+++ b/main_test.go
@@ -10,29 +10,29 @@ import (
 const expectedResult = `
 | Test Suite | $Status$ | $±Time$ | $±Tests$ | $±Skipped$ | $±Failures$ | $±Errors$ |
 |:----:|:----:|:----:|:-----:|:-------:|:--------:|:------:|
-| $testsuite1$ | $ $ | $+0.300$ | $+2$ | $+2$ | $0$ | $-2$ |
-| $testsuite2$ | $ $ | $0.000$ | $-1$ | $+2$ | $-2$ | $0$ |
-| $testsuite3$ | $ ➖$ | $-3.250$ | $-4$ | $0$ | $-3$ | $0$ |
-| $testsuite5$ | $ ➕$ | $+7.158$ | $+3$ | $0$ | $0$ | $+1$ |
+| testsuite1 |  | $+0.300$ | $+2$ | $+2$ | $0$ | $-2$ |
+| testsuite2 |  | $0.000$ | $-1$ | $+2$ | $-2$ | $0$ |
+| testsuite3 | $-$ | $-3.250$ | $-4$ | $0$ | $-3$ | $0$ |
+| testsuite5 | $+$ | $+7.158$ | $+3$ | $0$ | $0$ | $+1$ |
 
 <details>
   <summary><b>Additional test case details</b></summary>
 
-| Test Case | $Status$ | $±Time$ | Test Suite |
-|:----:|:----:|:----:|:----:|
-| testcase1 | $ $ | $+5.960$ | testsuite1 |
-| testcase2 | $ $ | $0.000$ | testsuite1 |
-| testcase3 | $ $ | $0.000$ | testsuite1 |
-| testcase3a | $ ➕$ | $+0.550$ | testsuite1 |
-| testcase3b | $ ➕$ | $+0.550$ | testsuite1 |
-| testcase4 | $ $ | $-0.100$ | testsuite2 |
-| testcase5 | $ $ | $+2.000$ | testsuite2 |
-| testcase6 | $ ➖$ | $+0.080$ | testsuite2 |
-| testcase40 | $ ➖$ | $+0.250$ | testsuite3 |
-| testcase50 | $ ➖$ | $+0.800$ | testsuite3 |
-| testcase60 | $ ➖$ | $+0.580$ | testsuite3 |
-| testcase400 | $ ➕$ | $+1.150$ | testsuite5 |
-| testcase500 | $ ➕$ | $+5.111$ | testsuite5 |
+| Test Suite | $Status$ | $±Time$ | Test Case |
+|:----:|:----:|:----:|:-----|
+| testsuite1 |  | $+5.960$ | testcase1 |
+| testsuite1 |  | $0.000$ | testcase2 |
+| testsuite1 |  | $0.000$ | testcase3 |
+| testsuite1 | $+$ | $+0.550$ | testcase3a |
+| testsuite1 | $+$ | $+0.550$ | testcase3b |
+| testsuite2 |  | $-0.100$ | testcase4 |
+| testsuite2 |  | $+2.000$ | testcase5 |
+| testsuite2 | $-$ | $+0.080$ | testcase6 |
+| testsuite3 | $-$ | $+0.250$ | testcase40 |
+| testsuite3 | $-$ | $+0.800$ | testcase50 |
+| testsuite3 | $-$ | $+0.580$ | testcase60 |
+| testsuite5 | $+$ | $+1.150$ | testcase400 |
+| testsuite5 | $+$ | $+5.111$ | testcase500 |
 </details>
 `
 

--- a/testdata/new.xml
+++ b/testdata/new.xml
@@ -1,86 +1,21 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
-The MIT License
-Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Erik Ramfelt
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
--->
-
+<?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="WLI-FI-Tests-Fake" tests="6" failures="1" errors="0" time="1412" package="IT-Interface-WLI-FI" id="1">
-    <properties>
-      <property name="java.runtime.name" value="Java(TM) SE Runtime Environment"/>
-      <property name="sun.boot.library.path" value="C:\Program Files\Java\jdk1.6.0_02\jre\bin"/>
-      <property name="java.vm.version" value="1.6.0_02-b06"/>
-      <property name="java.vm.vendor" value="Sun Microsystems Inc."/>
-      <property name="java.vendor.url" value="http://java.sun.com/"/>
-      <property name="path.separator" value=";"/>
-      <property name="java.vm.name" value="Java HotSpot(TM) Client VM"/>
-      <property name="file.encoding.pkg" value="sun.io"/>
-      <property name="sun.java.launcher" value="SUN_STANDARD"/>
-      <property name="user.country" value="NO"/>
-      <property name="sun.os.patch.level" value="Service Pack 2"/>
-      <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
-      <property name="user.dir" value="C:\CI\hudson\jobs\Interface_WLI-FI-Fake\workspace"/>
-      <property name="java.runtime.version" value="1.6.0_02-b06"/>
-      <property name="java.awt.graphicsenv" value="sun.awt.Win32GraphicsEnvironment"/>
-      <property name="java.endorsed.dirs" value="C:\Program Files\Java\jdk1.6.0_02\jre\lib\endorsed"/>
-      <property name="os.arch" value="x86"/>
-      <property name="java.io.tmpdir" value="C:\Documents and Settings\e5274\Local Settings\Temp\"/>
-      <property name="line.separator" value="
-"/>
-      <property name="java.vm.specification.vendor" value="Sun Microsystems Inc."/>
-      <property name="user.variant" value=""/>
-      <property name="os.name" value="Windows XP"/>
-      <property name="sun.jnu.encoding" value="Cp1252"/>
-      <property name="java.library.path" value="C:\Program Files\Java\jdk1.6.0_02\bin;.;C:\WINDOWS\Sun\Java\bin;C:\WINDOWS\system32;C:\WINDOWS;C:\Program Files\Java\jdk1.6.0_02\bin;C:\PROGRA~1\COMPUW~1\FILE-A~1\Dme;C:\PROGRA~1\COMPUW~1\FILE-A~1;C:\WINDOWS\system32;C:\WINDOWS;C:\WINDOWS\System32\Wbem;C:\oracle\ora92\jre\1.4.2\bin\client\;C:\oracle\ora92\jre\1.4.2\bin;c:\oracle\ora92\bin;C:\Program Files\Oracle\jre\1.1.8\bin;C:\Program Files\IBM\Personal Communications\;C:\Program Files\IBM\Trace Facility\;C:\Groovy\groovy-1.1-RC1\bin;C:\Program Files\Subversion\bin;C:\Program Files\GnuWin32\bin;C:\Program Files\putty;C:\Program Files\Common Files\Compuware"/>
-      <property name="java.specification.name" value="Java Platform API Specification"/>
-      <property name="java.class.version" value="50.0"/>
-      <property name="sun.management.compiler" value="HotSpot Client Compiler"/>
-      <property name="os.version" value="5.1"/>
-      <property name="user.home" value="C:\Documents and Settings\e5274"/>
-      <property name="user.timezone" value="Europe/Berlin"/>
-      <property name="java.awt.printerjob" value="sun.awt.windows.WPrinterJob"/>
-      <property name="file.encoding" value="Cp1252"/>
-      <property name="java.specification.version" value="1.6"/>
-      <property name="java.class.path" value="C:\eviware\soapUI-Pro-1.7.6\bin\soapui-pro-1.7.6.jar;C:\eviware\soapUI-Pro-1.7.6\lib\activation-1.1.jar;C:\eviware\soapUI-Pro-1.7.6\lib\javamail-1.4.jar;C:\eviware\soapUI-Pro-1.7.6\lib\wsdl4j-1.6.2-fixed.jar;C:\eviware\soapUI-Pro-1.7.6\lib\junit-3.8.1.jar;C:\eviware\soapUI-Pro-1.7.6\lib\log4j-1.2.14.jar;C:\eviware\soapUI-Pro-1.7.6\lib\looks-2.1.2.jar;C:\eviware\soapUI-Pro-1.7.6\lib\forms-1.0.7.jar;C:\eviware\soapUI-Pro-1.7.6\lib\jcalendar-1.3.2.jar;C:\eviware\soapUI-Pro-1.7.6\lib\commons-logging-1.1.jar;C:\eviware\soapUI-Pro-1.7.6\lib\not-yet-commons-ssl-0.3.8.jar;C:\eviware\soapUI-Pro-1.7.6\lib\commons-cli-1.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\commons-beanutils-1.7.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\commons-httpclient-3.0.1-soapui.jar;C:\eviware\soapUI-Pro-1.7.6\lib\swingx-SNAPSHOT.jar;C:\eviware\soapUI-Pro-1.7.6\lib\l2fprod-common-fontchooser-0.2-dev.jar;C:\eviware\soapUI-Pro-1.7.6\lib\commons-codec-1.3.jar;C:\eviware\soapUI-Pro-1.7.6\lib\groovy-all-1.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\jetty-6.1.5.jar;C:\eviware\soapUI-Pro-1.7.6\lib\jetty-util-6.1.5.jar;C:\eviware\soapUI-Pro-1.7.6\lib\servlet-api-2.5-6.1.5.jar;C:\eviware\soapUI-Pro-1.7.6\lib\jxl-2.6.5.jar;C:\eviware\soapUI-Pro-1.7.6\lib\idw-1.5.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\ant-1.6.1.jar;C:\eviware\soapUI-Pro-1.7.6\lib\xbean-2.3.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\xbean_xpath-2.3.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\xmlpublic-2.3.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\jsr173_1.0_api-xmlbeans-2.3.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\soapui-xmlbeans-1.7.6.jar;C:\eviware\soapUI-Pro-1.7.6\lib\license4j-1.3.jar;C:\eviware\soapUI-Pro-1.7.6\lib\soapui-1.7.6.jar;C:\eviware\soapUI-Pro-1.7.6\lib\soap-xmlbeans-1.2.jar;C:\eviware\soapUI-Pro-1.7.6\lib\j2ee-xmlbeans-1.4.jar;C:\eviware\soapUI-Pro-1.7.6\lib\ext-xmlbeans-1.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\saxon-8.8.jar;C:\eviware\soapUI-Pro-1.7.6\lib\saxon-dom-8.8.jar;C:\eviware\soapUI-Pro-1.7.6\lib\xmlunit-1.1.jar;C:\eviware\soapUI-Pro-1.7.6\lib\xmlsec-1.2.1.jar;C:\eviware\soapUI-Pro-1.7.6\lib\xalan-2.6.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\dtd-xercesImpl-2.9.1.jar;C:\eviware\soapUI-Pro-1.7.6\lib\wss4j-1.5.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\bcprov-jdk15-133.jar"/>
-      <property name="user.name" value="e5274"/>
-      <property name="java.vm.specification.version" value="1.0"/>
-      <property name="java.home" value="C:\Program Files\Java\jdk1.6.0_02\jre"/>
-      <property name="sun.arch.data.model" value="32"/>
-      <property name="user.language" value="no"/>
-      <property name="java.specification.vendor" value="Sun Microsystems Inc."/>
-      <property name="awt.toolkit" value="sun.awt.windows.WToolkit"/>
-      <property name="java.vm.info" value="mixed mode"/>
-      <property name="java.version" value="1.6.0_02"/>
-      <property name="java.ext.dirs" value="C:\Program Files\Java\jdk1.6.0_02\jre\lib\ext;C:\WINDOWS\Sun\Java\lib\ext"/>
-      <property name="sun.boot.class.path" value="C:\Program Files\Java\jdk1.6.0_02\jre\lib\resources.jar;C:\Program Files\Java\jdk1.6.0_02\jre\lib\rt.jar;C:\Program Files\Java\jdk1.6.0_02\jre\lib\sunrsasign.jar;C:\Program Files\Java\jdk1.6.0_02\jre\lib\jsse.jar;C:\Program Files\Java\jdk1.6.0_02\jre\lib\jce.jar;C:\Program Files\Java\jdk1.6.0_02\jre\lib\charsets.jar;C:\Program Files\Java\jdk1.6.0_02\jre\classes"/>
-      <property name="java.vendor" value="Sun Microsystems Inc."/>
-      <property name="file.separator" value="\"/>
-      <property name="java.vendor.url.bug" value="http://java.sun.com/cgi-bin/bugreport.cgi"/>
-      <property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
-      <property name="sun.cpu.endian" value="little"/>
-      <property name="sun.desktop" value="windows"/>
-      <property name="sun.cpu.isalist" value=""/>
-    </properties>
-    <testcase name="IF_importTradeConfirmationToDwh" time="198.0"/>
-    <testcase name="IF_getAmartaDisbursements" time="119.0"/>
-    <testcase name="IF_importGLReconDataToDwh" time="423.0"/>
-    <testcase name="IF_importTradeInstructionsToDwh" time="278.0"/>
-    <testcase name="IF_getDeviationTradeInstructions" time="408.0"/>
-    <testcase name="IF_getDwhGLData" time="0.0"/>
+  <testsuite name="testsuite1" timestamp="2023-01-19T16:20:10Z" hostname="e3ab08c8a5fd" tests="6" skipped="2" failures="0" errors="0" time="1.55">
+    <testcase time="1.85" classname="testsuite1" name="testcase1"/>
+    <testcase time="5.32" classname="testsuite1" name="testcase1"/>
+    <testcase time="0.32" classname="testsuite1" name="testcase2"/>
+    <testcase time="0.55" classname="testsuite1" name="testcase3"/>
+    <testcase time="0.55" classname="testsuite1" name="testcase3a"/>
+    <testcase time="0.55" classname="testsuite1" name="testcase3b"/>
+  </testsuite>
+  <testsuite name="testsuite2" timestamp="2023-01-19T16:20:10Z" hostname="e3ab08c8a5fd" tests="3" skipped="2" failures="1" errors="0" time="2.25">
+    <testcase time="0.05" classname="testsuite2" name="testcase4"/>
+    <testcase time="2.05" classname="testsuite2" name="testcase5"/>
+    <testcase time="0.05" classname="testsuite2" name="testcase5"/>
+  </testsuite>
+  <testsuite name="testsuite5" timestamp="2023-01-19T16:20:10Z" hostname="e3ab08c8a5fd" tests="3" skipped="0" failures="0" errors="1" time="7.158">
+    <testcase time="1.15" classname="testsuite5" name="testcase400"/>
+    <testcase time="2.05" classname="testsuite5" name="testcase500"/>
+    <testcase time="3.061" classname="testsuite5" name="testcase500"/>
   </testsuite>
 </testsuites>

--- a/testdata/new.xml
+++ b/testdata/new.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+The MIT License
+Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Erik Ramfelt
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<testsuites>
+  <testsuite name="WLI-FI-Tests-Fake" tests="6" failures="1" errors="0" time="1412" package="IT-Interface-WLI-FI" id="1">
+    <properties>
+      <property name="java.runtime.name" value="Java(TM) SE Runtime Environment"/>
+      <property name="sun.boot.library.path" value="C:\Program Files\Java\jdk1.6.0_02\jre\bin"/>
+      <property name="java.vm.version" value="1.6.0_02-b06"/>
+      <property name="java.vm.vendor" value="Sun Microsystems Inc."/>
+      <property name="java.vendor.url" value="http://java.sun.com/"/>
+      <property name="path.separator" value=";"/>
+      <property name="java.vm.name" value="Java HotSpot(TM) Client VM"/>
+      <property name="file.encoding.pkg" value="sun.io"/>
+      <property name="sun.java.launcher" value="SUN_STANDARD"/>
+      <property name="user.country" value="NO"/>
+      <property name="sun.os.patch.level" value="Service Pack 2"/>
+      <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+      <property name="user.dir" value="C:\CI\hudson\jobs\Interface_WLI-FI-Fake\workspace"/>
+      <property name="java.runtime.version" value="1.6.0_02-b06"/>
+      <property name="java.awt.graphicsenv" value="sun.awt.Win32GraphicsEnvironment"/>
+      <property name="java.endorsed.dirs" value="C:\Program Files\Java\jdk1.6.0_02\jre\lib\endorsed"/>
+      <property name="os.arch" value="x86"/>
+      <property name="java.io.tmpdir" value="C:\Documents and Settings\e5274\Local Settings\Temp\"/>
+      <property name="line.separator" value="
+"/>
+      <property name="java.vm.specification.vendor" value="Sun Microsystems Inc."/>
+      <property name="user.variant" value=""/>
+      <property name="os.name" value="Windows XP"/>
+      <property name="sun.jnu.encoding" value="Cp1252"/>
+      <property name="java.library.path" value="C:\Program Files\Java\jdk1.6.0_02\bin;.;C:\WINDOWS\Sun\Java\bin;C:\WINDOWS\system32;C:\WINDOWS;C:\Program Files\Java\jdk1.6.0_02\bin;C:\PROGRA~1\COMPUW~1\FILE-A~1\Dme;C:\PROGRA~1\COMPUW~1\FILE-A~1;C:\WINDOWS\system32;C:\WINDOWS;C:\WINDOWS\System32\Wbem;C:\oracle\ora92\jre\1.4.2\bin\client\;C:\oracle\ora92\jre\1.4.2\bin;c:\oracle\ora92\bin;C:\Program Files\Oracle\jre\1.1.8\bin;C:\Program Files\IBM\Personal Communications\;C:\Program Files\IBM\Trace Facility\;C:\Groovy\groovy-1.1-RC1\bin;C:\Program Files\Subversion\bin;C:\Program Files\GnuWin32\bin;C:\Program Files\putty;C:\Program Files\Common Files\Compuware"/>
+      <property name="java.specification.name" value="Java Platform API Specification"/>
+      <property name="java.class.version" value="50.0"/>
+      <property name="sun.management.compiler" value="HotSpot Client Compiler"/>
+      <property name="os.version" value="5.1"/>
+      <property name="user.home" value="C:\Documents and Settings\e5274"/>
+      <property name="user.timezone" value="Europe/Berlin"/>
+      <property name="java.awt.printerjob" value="sun.awt.windows.WPrinterJob"/>
+      <property name="file.encoding" value="Cp1252"/>
+      <property name="java.specification.version" value="1.6"/>
+      <property name="java.class.path" value="C:\eviware\soapUI-Pro-1.7.6\bin\soapui-pro-1.7.6.jar;C:\eviware\soapUI-Pro-1.7.6\lib\activation-1.1.jar;C:\eviware\soapUI-Pro-1.7.6\lib\javamail-1.4.jar;C:\eviware\soapUI-Pro-1.7.6\lib\wsdl4j-1.6.2-fixed.jar;C:\eviware\soapUI-Pro-1.7.6\lib\junit-3.8.1.jar;C:\eviware\soapUI-Pro-1.7.6\lib\log4j-1.2.14.jar;C:\eviware\soapUI-Pro-1.7.6\lib\looks-2.1.2.jar;C:\eviware\soapUI-Pro-1.7.6\lib\forms-1.0.7.jar;C:\eviware\soapUI-Pro-1.7.6\lib\jcalendar-1.3.2.jar;C:\eviware\soapUI-Pro-1.7.6\lib\commons-logging-1.1.jar;C:\eviware\soapUI-Pro-1.7.6\lib\not-yet-commons-ssl-0.3.8.jar;C:\eviware\soapUI-Pro-1.7.6\lib\commons-cli-1.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\commons-beanutils-1.7.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\commons-httpclient-3.0.1-soapui.jar;C:\eviware\soapUI-Pro-1.7.6\lib\swingx-SNAPSHOT.jar;C:\eviware\soapUI-Pro-1.7.6\lib\l2fprod-common-fontchooser-0.2-dev.jar;C:\eviware\soapUI-Pro-1.7.6\lib\commons-codec-1.3.jar;C:\eviware\soapUI-Pro-1.7.6\lib\groovy-all-1.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\jetty-6.1.5.jar;C:\eviware\soapUI-Pro-1.7.6\lib\jetty-util-6.1.5.jar;C:\eviware\soapUI-Pro-1.7.6\lib\servlet-api-2.5-6.1.5.jar;C:\eviware\soapUI-Pro-1.7.6\lib\jxl-2.6.5.jar;C:\eviware\soapUI-Pro-1.7.6\lib\idw-1.5.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\ant-1.6.1.jar;C:\eviware\soapUI-Pro-1.7.6\lib\xbean-2.3.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\xbean_xpath-2.3.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\xmlpublic-2.3.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\jsr173_1.0_api-xmlbeans-2.3.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\soapui-xmlbeans-1.7.6.jar;C:\eviware\soapUI-Pro-1.7.6\lib\license4j-1.3.jar;C:\eviware\soapUI-Pro-1.7.6\lib\soapui-1.7.6.jar;C:\eviware\soapUI-Pro-1.7.6\lib\soap-xmlbeans-1.2.jar;C:\eviware\soapUI-Pro-1.7.6\lib\j2ee-xmlbeans-1.4.jar;C:\eviware\soapUI-Pro-1.7.6\lib\ext-xmlbeans-1.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\saxon-8.8.jar;C:\eviware\soapUI-Pro-1.7.6\lib\saxon-dom-8.8.jar;C:\eviware\soapUI-Pro-1.7.6\lib\xmlunit-1.1.jar;C:\eviware\soapUI-Pro-1.7.6\lib\xmlsec-1.2.1.jar;C:\eviware\soapUI-Pro-1.7.6\lib\xalan-2.6.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\dtd-xercesImpl-2.9.1.jar;C:\eviware\soapUI-Pro-1.7.6\lib\wss4j-1.5.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\bcprov-jdk15-133.jar"/>
+      <property name="user.name" value="e5274"/>
+      <property name="java.vm.specification.version" value="1.0"/>
+      <property name="java.home" value="C:\Program Files\Java\jdk1.6.0_02\jre"/>
+      <property name="sun.arch.data.model" value="32"/>
+      <property name="user.language" value="no"/>
+      <property name="java.specification.vendor" value="Sun Microsystems Inc."/>
+      <property name="awt.toolkit" value="sun.awt.windows.WToolkit"/>
+      <property name="java.vm.info" value="mixed mode"/>
+      <property name="java.version" value="1.6.0_02"/>
+      <property name="java.ext.dirs" value="C:\Program Files\Java\jdk1.6.0_02\jre\lib\ext;C:\WINDOWS\Sun\Java\lib\ext"/>
+      <property name="sun.boot.class.path" value="C:\Program Files\Java\jdk1.6.0_02\jre\lib\resources.jar;C:\Program Files\Java\jdk1.6.0_02\jre\lib\rt.jar;C:\Program Files\Java\jdk1.6.0_02\jre\lib\sunrsasign.jar;C:\Program Files\Java\jdk1.6.0_02\jre\lib\jsse.jar;C:\Program Files\Java\jdk1.6.0_02\jre\lib\jce.jar;C:\Program Files\Java\jdk1.6.0_02\jre\lib\charsets.jar;C:\Program Files\Java\jdk1.6.0_02\jre\classes"/>
+      <property name="java.vendor" value="Sun Microsystems Inc."/>
+      <property name="file.separator" value="\"/>
+      <property name="java.vendor.url.bug" value="http://java.sun.com/cgi-bin/bugreport.cgi"/>
+      <property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+      <property name="sun.cpu.endian" value="little"/>
+      <property name="sun.desktop" value="windows"/>
+      <property name="sun.cpu.isalist" value=""/>
+    </properties>
+    <testcase name="IF_importTradeConfirmationToDwh" time="198.0"/>
+    <testcase name="IF_getAmartaDisbursements" time="119.0"/>
+    <testcase name="IF_importGLReconDataToDwh" time="423.0"/>
+    <testcase name="IF_importTradeInstructionsToDwh" time="278.0"/>
+    <testcase name="IF_getDeviationTradeInstructions" time="408.0"/>
+    <testcase name="IF_getDwhGLData" time="0.0"/>
+  </testsuite>
+</testsuites>

--- a/testdata/new.xml
+++ b/testdata/new.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="testsuite1" timestamp="2023-01-19T16:20:10Z" hostname="e3ab08c8a5fd" tests="6" skipped="2" failures="0" errors="0" time="1.55">
+  <testsuite name="testsuite1" timestamp="2023-01-19T16:20:10Z" hostname="e3ab08c8a5fd" tests="6" skipped="2" failures="0" errors="0" time="2.55">
     <testcase time="1.85" classname="testsuite1" name="testcase1"/>
     <testcase time="5.32" classname="testsuite1" name="testcase1"/>
     <testcase time="0.32" classname="testsuite1" name="testcase2"/>

--- a/testdata/old.xml
+++ b/testdata/old.xml
@@ -7,7 +7,7 @@
     <testcase time="0.55" classname="testsuite1" name="testcase3"/>
   </testsuite>
   <testsuite name="testsuite2" timestamp="2023-01-19T16:20:10Z" hostname="e3ab08c8a5fd" tests="4" skipped="0" failures="3" errors="0" time="2.25">
-    <testcase time="0.15" classname="testsuite2" name="testcase4"/>
+    <testcase time="5.15" classname="testsuite2" name="testcase4"/>
     <testcase time="0.05" classname="testsuite2" name="testcase5"/>
     <testcase time="0.05" classname="testsuite2" name="testcase5"/>
     <testcase time="0.08" classname="testsuite2" name="testcase6"/>

--- a/testdata/old.xml
+++ b/testdata/old.xml
@@ -1,86 +1,21 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
-The MIT License
-Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Erik Ramfelt
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
--->
-
+<?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="WLI-FI-Tests-Fake" tests="6" failures="0" errors="0" time="1426" package="IT-Interface-WLI-FI" id="1">
-    <properties>
-      <property name="java.runtime.name" value="Java(TM) SE Runtime Environment"/>
-      <property name="sun.boot.library.path" value="C:\Program Files\Java\jdk1.6.0_02\jre\bin"/>
-      <property name="java.vm.version" value="1.6.0_02-b06"/>
-      <property name="java.vm.vendor" value="Sun Microsystems Inc."/>
-      <property name="java.vendor.url" value="http://java.sun.com/"/>
-      <property name="path.separator" value=";"/>
-      <property name="java.vm.name" value="Java HotSpot(TM) Client VM"/>
-      <property name="file.encoding.pkg" value="sun.io"/>
-      <property name="sun.java.launcher" value="SUN_STANDARD"/>
-      <property name="user.country" value="NO"/>
-      <property name="sun.os.patch.level" value="Service Pack 2"/>
-      <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
-      <property name="user.dir" value="C:\CI\hudson\jobs\Interface_WLI-FI-Fake\workspace"/>
-      <property name="java.runtime.version" value="1.6.0_02-b06"/>
-      <property name="java.awt.graphicsenv" value="sun.awt.Win32GraphicsEnvironment"/>
-      <property name="java.endorsed.dirs" value="C:\Program Files\Java\jdk1.6.0_02\jre\lib\endorsed"/>
-      <property name="os.arch" value="x86"/>
-      <property name="java.io.tmpdir" value="C:\Documents and Settings\e5274\Local Settings\Temp\"/>
-      <property name="line.separator" value="
-"/>
-      <property name="java.vm.specification.vendor" value="Sun Microsystems Inc."/>
-      <property name="user.variant" value=""/>
-      <property name="os.name" value="Windows XP"/>
-      <property name="sun.jnu.encoding" value="Cp1252"/>
-      <property name="java.library.path" value="C:\Program Files\Java\jdk1.6.0_02\bin;.;C:\WINDOWS\Sun\Java\bin;C:\WINDOWS\system32;C:\WINDOWS;C:\Program Files\Java\jdk1.6.0_02\bin;C:\PROGRA~1\COMPUW~1\FILE-A~1\Dme;C:\PROGRA~1\COMPUW~1\FILE-A~1;C:\WINDOWS\system32;C:\WINDOWS;C:\WINDOWS\System32\Wbem;C:\oracle\ora92\jre\1.4.2\bin\client\;C:\oracle\ora92\jre\1.4.2\bin;c:\oracle\ora92\bin;C:\Program Files\Oracle\jre\1.1.8\bin;C:\Program Files\IBM\Personal Communications\;C:\Program Files\IBM\Trace Facility\;C:\Groovy\groovy-1.1-RC1\bin;C:\Program Files\Subversion\bin;C:\Program Files\GnuWin32\bin;C:\Program Files\putty;C:\Program Files\Common Files\Compuware"/>
-      <property name="java.specification.name" value="Java Platform API Specification"/>
-      <property name="java.class.version" value="50.0"/>
-      <property name="sun.management.compiler" value="HotSpot Client Compiler"/>
-      <property name="os.version" value="5.1"/>
-      <property name="user.home" value="C:\Documents and Settings\e5274"/>
-      <property name="user.timezone" value="Europe/Berlin"/>
-      <property name="java.awt.printerjob" value="sun.awt.windows.WPrinterJob"/>
-      <property name="file.encoding" value="Cp1252"/>
-      <property name="java.specification.version" value="1.6"/>
-      <property name="java.class.path" value="C:\eviware\soapUI-Pro-1.7.6\bin\soapui-pro-1.7.6.jar;C:\eviware\soapUI-Pro-1.7.6\lib\activation-1.1.jar;C:\eviware\soapUI-Pro-1.7.6\lib\javamail-1.4.jar;C:\eviware\soapUI-Pro-1.7.6\lib\wsdl4j-1.6.2-fixed.jar;C:\eviware\soapUI-Pro-1.7.6\lib\junit-3.8.1.jar;C:\eviware\soapUI-Pro-1.7.6\lib\log4j-1.2.14.jar;C:\eviware\soapUI-Pro-1.7.6\lib\looks-2.1.2.jar;C:\eviware\soapUI-Pro-1.7.6\lib\forms-1.0.7.jar;C:\eviware\soapUI-Pro-1.7.6\lib\jcalendar-1.3.2.jar;C:\eviware\soapUI-Pro-1.7.6\lib\commons-logging-1.1.jar;C:\eviware\soapUI-Pro-1.7.6\lib\not-yet-commons-ssl-0.3.8.jar;C:\eviware\soapUI-Pro-1.7.6\lib\commons-cli-1.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\commons-beanutils-1.7.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\commons-httpclient-3.0.1-soapui.jar;C:\eviware\soapUI-Pro-1.7.6\lib\swingx-SNAPSHOT.jar;C:\eviware\soapUI-Pro-1.7.6\lib\l2fprod-common-fontchooser-0.2-dev.jar;C:\eviware\soapUI-Pro-1.7.6\lib\commons-codec-1.3.jar;C:\eviware\soapUI-Pro-1.7.6\lib\groovy-all-1.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\jetty-6.1.5.jar;C:\eviware\soapUI-Pro-1.7.6\lib\jetty-util-6.1.5.jar;C:\eviware\soapUI-Pro-1.7.6\lib\servlet-api-2.5-6.1.5.jar;C:\eviware\soapUI-Pro-1.7.6\lib\jxl-2.6.5.jar;C:\eviware\soapUI-Pro-1.7.6\lib\idw-1.5.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\ant-1.6.1.jar;C:\eviware\soapUI-Pro-1.7.6\lib\xbean-2.3.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\xbean_xpath-2.3.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\xmlpublic-2.3.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\jsr173_1.0_api-xmlbeans-2.3.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\soapui-xmlbeans-1.7.6.jar;C:\eviware\soapUI-Pro-1.7.6\lib\license4j-1.3.jar;C:\eviware\soapUI-Pro-1.7.6\lib\soapui-1.7.6.jar;C:\eviware\soapUI-Pro-1.7.6\lib\soap-xmlbeans-1.2.jar;C:\eviware\soapUI-Pro-1.7.6\lib\j2ee-xmlbeans-1.4.jar;C:\eviware\soapUI-Pro-1.7.6\lib\ext-xmlbeans-1.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\saxon-8.8.jar;C:\eviware\soapUI-Pro-1.7.6\lib\saxon-dom-8.8.jar;C:\eviware\soapUI-Pro-1.7.6\lib\xmlunit-1.1.jar;C:\eviware\soapUI-Pro-1.7.6\lib\xmlsec-1.2.1.jar;C:\eviware\soapUI-Pro-1.7.6\lib\xalan-2.6.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\dtd-xercesImpl-2.9.1.jar;C:\eviware\soapUI-Pro-1.7.6\lib\wss4j-1.5.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\bcprov-jdk15-133.jar"/>
-      <property name="user.name" value="e5274"/>
-      <property name="java.vm.specification.version" value="1.0"/>
-      <property name="java.home" value="C:\Program Files\Java\jdk1.6.0_02\jre"/>
-      <property name="sun.arch.data.model" value="32"/>
-      <property name="user.language" value="no"/>
-      <property name="java.specification.vendor" value="Sun Microsystems Inc."/>
-      <property name="awt.toolkit" value="sun.awt.windows.WToolkit"/>
-      <property name="java.vm.info" value="mixed mode"/>
-      <property name="java.version" value="1.6.0_02"/>
-      <property name="java.ext.dirs" value="C:\Program Files\Java\jdk1.6.0_02\jre\lib\ext;C:\WINDOWS\Sun\Java\lib\ext"/>
-      <property name="sun.boot.class.path" value="C:\Program Files\Java\jdk1.6.0_02\jre\lib\resources.jar;C:\Program Files\Java\jdk1.6.0_02\jre\lib\rt.jar;C:\Program Files\Java\jdk1.6.0_02\jre\lib\sunrsasign.jar;C:\Program Files\Java\jdk1.6.0_02\jre\lib\jsse.jar;C:\Program Files\Java\jdk1.6.0_02\jre\lib\jce.jar;C:\Program Files\Java\jdk1.6.0_02\jre\lib\charsets.jar;C:\Program Files\Java\jdk1.6.0_02\jre\classes"/>
-      <property name="java.vendor" value="Sun Microsystems Inc."/>
-      <property name="file.separator" value="\"/>
-      <property name="java.vendor.url.bug" value="http://java.sun.com/cgi-bin/bugreport.cgi"/>
-      <property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
-      <property name="sun.cpu.endian" value="little"/>
-      <property name="sun.desktop" value="windows"/>
-      <property name="sun.cpu.isalist" value=""/>
-    </properties>
-    <testcase name="IF_importTradeConfirmationToDwh" time="198.0"/>
-    <testcase name="IF_getAmartaDisbursements" time="119.0"/>
-    <testcase name="IF_importGLReconDataToDwh" time="423.0"/>
-    <testcase name="IF_importTradeInstructionsToDwh" time="278.0"/>
-    <testcase name="IF_getDeviationTradeInstructions" time="408.0"/>
-    <testcase name="IF_getDwhGLData" time="0.0"/>
+  <testsuite name="testsuite1" timestamp="2023-01-19T16:20:10Z" hostname="e3ab08c8a5fd" tests="4" skipped="0" failures="0" errors="2" time="1.25">
+    <testcase time="0.85" classname="testsuite1" name="testcase1"/>
+    <testcase time="0.36" classname="testsuite1" name="testcase1"/>
+    <testcase time="0.32" classname="testsuite1" name="testcase2"/>
+    <testcase time="0.55" classname="testsuite1" name="testcase3"/>
+  </testsuite>
+  <testsuite name="testsuite2" timestamp="2023-01-19T16:20:10Z" hostname="e3ab08c8a5fd" tests="4" skipped="0" failures="3" errors="0" time="2.25">
+    <testcase time="0.15" classname="testsuite2" name="testcase4"/>
+    <testcase time="0.05" classname="testsuite2" name="testcase5"/>
+    <testcase time="0.05" classname="testsuite2" name="testcase5"/>
+    <testcase time="0.08" classname="testsuite2" name="testcase6"/>
+  </testsuite>
+  <testsuite name="testsuite3" timestamp="2023-01-19T16:20:10Z" hostname="e3ab08c8a5fd" tests="4" skipped="0" failures="3" errors="0" time="3.25">
+    <testcase time="0.25" classname="testsuite3" name="testcase40"/>
+    <testcase time="0.35" classname="testsuite3" name="testcase50"/>
+    <testcase time="0.45" classname="testsuite3" name="testcase50"/>
+    <testcase time="0.58" classname="testsuite3" name="testcase60"/>
   </testsuite>
 </testsuites>

--- a/testdata/old.xml
+++ b/testdata/old.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+The MIT License
+Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Erik Ramfelt
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<testsuites>
+  <testsuite name="WLI-FI-Tests-Fake" tests="6" failures="0" errors="0" time="1426" package="IT-Interface-WLI-FI" id="1">
+    <properties>
+      <property name="java.runtime.name" value="Java(TM) SE Runtime Environment"/>
+      <property name="sun.boot.library.path" value="C:\Program Files\Java\jdk1.6.0_02\jre\bin"/>
+      <property name="java.vm.version" value="1.6.0_02-b06"/>
+      <property name="java.vm.vendor" value="Sun Microsystems Inc."/>
+      <property name="java.vendor.url" value="http://java.sun.com/"/>
+      <property name="path.separator" value=";"/>
+      <property name="java.vm.name" value="Java HotSpot(TM) Client VM"/>
+      <property name="file.encoding.pkg" value="sun.io"/>
+      <property name="sun.java.launcher" value="SUN_STANDARD"/>
+      <property name="user.country" value="NO"/>
+      <property name="sun.os.patch.level" value="Service Pack 2"/>
+      <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+      <property name="user.dir" value="C:\CI\hudson\jobs\Interface_WLI-FI-Fake\workspace"/>
+      <property name="java.runtime.version" value="1.6.0_02-b06"/>
+      <property name="java.awt.graphicsenv" value="sun.awt.Win32GraphicsEnvironment"/>
+      <property name="java.endorsed.dirs" value="C:\Program Files\Java\jdk1.6.0_02\jre\lib\endorsed"/>
+      <property name="os.arch" value="x86"/>
+      <property name="java.io.tmpdir" value="C:\Documents and Settings\e5274\Local Settings\Temp\"/>
+      <property name="line.separator" value="
+"/>
+      <property name="java.vm.specification.vendor" value="Sun Microsystems Inc."/>
+      <property name="user.variant" value=""/>
+      <property name="os.name" value="Windows XP"/>
+      <property name="sun.jnu.encoding" value="Cp1252"/>
+      <property name="java.library.path" value="C:\Program Files\Java\jdk1.6.0_02\bin;.;C:\WINDOWS\Sun\Java\bin;C:\WINDOWS\system32;C:\WINDOWS;C:\Program Files\Java\jdk1.6.0_02\bin;C:\PROGRA~1\COMPUW~1\FILE-A~1\Dme;C:\PROGRA~1\COMPUW~1\FILE-A~1;C:\WINDOWS\system32;C:\WINDOWS;C:\WINDOWS\System32\Wbem;C:\oracle\ora92\jre\1.4.2\bin\client\;C:\oracle\ora92\jre\1.4.2\bin;c:\oracle\ora92\bin;C:\Program Files\Oracle\jre\1.1.8\bin;C:\Program Files\IBM\Personal Communications\;C:\Program Files\IBM\Trace Facility\;C:\Groovy\groovy-1.1-RC1\bin;C:\Program Files\Subversion\bin;C:\Program Files\GnuWin32\bin;C:\Program Files\putty;C:\Program Files\Common Files\Compuware"/>
+      <property name="java.specification.name" value="Java Platform API Specification"/>
+      <property name="java.class.version" value="50.0"/>
+      <property name="sun.management.compiler" value="HotSpot Client Compiler"/>
+      <property name="os.version" value="5.1"/>
+      <property name="user.home" value="C:\Documents and Settings\e5274"/>
+      <property name="user.timezone" value="Europe/Berlin"/>
+      <property name="java.awt.printerjob" value="sun.awt.windows.WPrinterJob"/>
+      <property name="file.encoding" value="Cp1252"/>
+      <property name="java.specification.version" value="1.6"/>
+      <property name="java.class.path" value="C:\eviware\soapUI-Pro-1.7.6\bin\soapui-pro-1.7.6.jar;C:\eviware\soapUI-Pro-1.7.6\lib\activation-1.1.jar;C:\eviware\soapUI-Pro-1.7.6\lib\javamail-1.4.jar;C:\eviware\soapUI-Pro-1.7.6\lib\wsdl4j-1.6.2-fixed.jar;C:\eviware\soapUI-Pro-1.7.6\lib\junit-3.8.1.jar;C:\eviware\soapUI-Pro-1.7.6\lib\log4j-1.2.14.jar;C:\eviware\soapUI-Pro-1.7.6\lib\looks-2.1.2.jar;C:\eviware\soapUI-Pro-1.7.6\lib\forms-1.0.7.jar;C:\eviware\soapUI-Pro-1.7.6\lib\jcalendar-1.3.2.jar;C:\eviware\soapUI-Pro-1.7.6\lib\commons-logging-1.1.jar;C:\eviware\soapUI-Pro-1.7.6\lib\not-yet-commons-ssl-0.3.8.jar;C:\eviware\soapUI-Pro-1.7.6\lib\commons-cli-1.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\commons-beanutils-1.7.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\commons-httpclient-3.0.1-soapui.jar;C:\eviware\soapUI-Pro-1.7.6\lib\swingx-SNAPSHOT.jar;C:\eviware\soapUI-Pro-1.7.6\lib\l2fprod-common-fontchooser-0.2-dev.jar;C:\eviware\soapUI-Pro-1.7.6\lib\commons-codec-1.3.jar;C:\eviware\soapUI-Pro-1.7.6\lib\groovy-all-1.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\jetty-6.1.5.jar;C:\eviware\soapUI-Pro-1.7.6\lib\jetty-util-6.1.5.jar;C:\eviware\soapUI-Pro-1.7.6\lib\servlet-api-2.5-6.1.5.jar;C:\eviware\soapUI-Pro-1.7.6\lib\jxl-2.6.5.jar;C:\eviware\soapUI-Pro-1.7.6\lib\idw-1.5.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\ant-1.6.1.jar;C:\eviware\soapUI-Pro-1.7.6\lib\xbean-2.3.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\xbean_xpath-2.3.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\xmlpublic-2.3.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\jsr173_1.0_api-xmlbeans-2.3.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\soapui-xmlbeans-1.7.6.jar;C:\eviware\soapUI-Pro-1.7.6\lib\license4j-1.3.jar;C:\eviware\soapUI-Pro-1.7.6\lib\soapui-1.7.6.jar;C:\eviware\soapUI-Pro-1.7.6\lib\soap-xmlbeans-1.2.jar;C:\eviware\soapUI-Pro-1.7.6\lib\j2ee-xmlbeans-1.4.jar;C:\eviware\soapUI-Pro-1.7.6\lib\ext-xmlbeans-1.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\saxon-8.8.jar;C:\eviware\soapUI-Pro-1.7.6\lib\saxon-dom-8.8.jar;C:\eviware\soapUI-Pro-1.7.6\lib\xmlunit-1.1.jar;C:\eviware\soapUI-Pro-1.7.6\lib\xmlsec-1.2.1.jar;C:\eviware\soapUI-Pro-1.7.6\lib\xalan-2.6.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\dtd-xercesImpl-2.9.1.jar;C:\eviware\soapUI-Pro-1.7.6\lib\wss4j-1.5.0.jar;C:\eviware\soapUI-Pro-1.7.6\lib\bcprov-jdk15-133.jar"/>
+      <property name="user.name" value="e5274"/>
+      <property name="java.vm.specification.version" value="1.0"/>
+      <property name="java.home" value="C:\Program Files\Java\jdk1.6.0_02\jre"/>
+      <property name="sun.arch.data.model" value="32"/>
+      <property name="user.language" value="no"/>
+      <property name="java.specification.vendor" value="Sun Microsystems Inc."/>
+      <property name="awt.toolkit" value="sun.awt.windows.WToolkit"/>
+      <property name="java.vm.info" value="mixed mode"/>
+      <property name="java.version" value="1.6.0_02"/>
+      <property name="java.ext.dirs" value="C:\Program Files\Java\jdk1.6.0_02\jre\lib\ext;C:\WINDOWS\Sun\Java\lib\ext"/>
+      <property name="sun.boot.class.path" value="C:\Program Files\Java\jdk1.6.0_02\jre\lib\resources.jar;C:\Program Files\Java\jdk1.6.0_02\jre\lib\rt.jar;C:\Program Files\Java\jdk1.6.0_02\jre\lib\sunrsasign.jar;C:\Program Files\Java\jdk1.6.0_02\jre\lib\jsse.jar;C:\Program Files\Java\jdk1.6.0_02\jre\lib\jce.jar;C:\Program Files\Java\jdk1.6.0_02\jre\lib\charsets.jar;C:\Program Files\Java\jdk1.6.0_02\jre\classes"/>
+      <property name="java.vendor" value="Sun Microsystems Inc."/>
+      <property name="file.separator" value="\"/>
+      <property name="java.vendor.url.bug" value="http://java.sun.com/cgi-bin/bugreport.cgi"/>
+      <property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+      <property name="sun.cpu.endian" value="little"/>
+      <property name="sun.desktop" value="windows"/>
+      <property name="sun.cpu.isalist" value=""/>
+    </properties>
+    <testcase name="IF_importTradeConfirmationToDwh" time="198.0"/>
+    <testcase name="IF_getAmartaDisbursements" time="119.0"/>
+    <testcase name="IF_importGLReconDataToDwh" time="423.0"/>
+    <testcase name="IF_importTradeInstructionsToDwh" time="278.0"/>
+    <testcase name="IF_getDeviationTradeInstructions" time="408.0"/>
+    <testcase name="IF_getDwhGLData" time="0.0"/>
+  </testsuite>
+</testsuites>


### PR DESCRIPTION
Ideally we want to show the time diff of `testcase`s for a given `testsuite` and it should be a separate collapsible table under the heading of "Additional testcase time differences".

<img width="668" alt="Screen Shot 2023-01-30 at 6 56 03 AM" src="https://user-images.githubusercontent.com/26552821/215483654-0a6a0f57-6c68-41fa-ba14-c57095a1745c.png">
